### PR TITLE
Use GitHub OIDC for AWS deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,11 @@ on:
       - develop
     paths:
       - 'src/**'
+      - '.github/workflows/deploy.yml'
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   deploy:
@@ -18,9 +23,11 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::233907574649:role/github-actions-alchepnet-website-deployer
           aws-region: us-east-1
+          allowed-account-ids: 233907574649
+          role-duration-seconds: 900
+          role-session-name: GitHubActions-${{ github.run_id }}
 
       - name: Sync files to S3
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::233907574649:role/github-actions-alchepnet-website-deployer
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-alchepnet-website-deployer
           aws-region: us-east-1
-          allowed-account-ids: 233907574649
+          allowed-account-ids: ${{ secrets.AWS_ACCOUNT_ID }}
           role-duration-seconds: 900
           role-session-name: GitHubActions-${{ github.run_id }}
 


### PR DESCRIPTION
## Summary

- switch the develop deployment from static AWS access keys to the repository-specific GitHub OIDC role
- grant only the GitHub token and repository-content permissions required by the job
- include this workflow file in the path filter so merging the change exercises the real S3 and CloudFront deployment path

## AWS role

The github-actions-alchepnet-website-deployer role is already managed and applied through the ardac-dict Terraform state. It allows only:

- listing and uploading objects in test.alchepnet.org
- creating invalidations for CloudFront distribution EAIFBVSW6O5UF

DeleteObject and cross-repository writes are implicitly denied.

## Validation

- yamllint
- git diff --check

## Cutover

The existing github-actions-deployer key and repository credential secrets remain active for rollback. After this deployment and the ARDaC tagged deployment both succeed through OIDC, disable both legacy keys and rerun the successful workflows before starting the seven-day quarantine.