### PR TITLE
Enforce the allowed AWS account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-alchepnet-website-deployer
           aws-region: us-east-1


### PR DESCRIPTION
## Summary

Upgrade aws-actions/configure-aws-credentials from v4 to v5 so the existing allowed-account-ids input is recognized and enforced.

## Evidence

The OIDC deployment from merge commit 1ccf0d33 succeeded, uploaded the website, and completed its CloudFront invalidation. Its logs also showed that v4 ignored allowed-account-ids as an unexpected input. Version 5 adds support for this guard.

## Validation

- yamllint
- git diff --check

Merging this workflow-only fix triggers another real deployment because the workflow file is included in the path filter.