### PR TITLE
Manage GitHub Actions IAM in Alchepnet Terraform

### DIFF
--- a/terraform/github-actions-oidc.tf
+++ b/terraform/github-actions-oidc.tf
@@ -2,6 +2,8 @@ data "aws_iam_openid_connect_provider" "github_actions" {
   url = "https://token.actions.githubusercontent.com"
 }
 
+data "aws_caller_identity" "github_actions" {}
+
 data "aws_iam_policy_document" "github_actions_assume_role" {
   statement {
     effect  = "Allow"
@@ -21,7 +23,7 @@ data "aws_iam_policy_document" "github_actions_assume_role" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:Su-informatics-lab/alchepnet-website:ref:refs/heads/develop"]
+      values   = ["repo:${var.repository}:ref:refs/heads/develop"]
     }
   }
 }
@@ -48,7 +50,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
   statement {
     effect    = "Allow"
     actions   = ["cloudfront:CreateInvalidation"]
-    resources = ["arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/EAIFBVSW6O5UF"]
+    resources = ["arn:aws:cloudfront::${data.aws_caller_identity.github_actions.account_id}:distribution/EAIFBVSW6O5UF"]
   }
 }
 

--- a/terraform/github-actions-oidc.tf
+++ b/terraform/github-actions-oidc.tf
@@ -1,0 +1,69 @@
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:Su-informatics-lab/alchepnet-website:ref:refs/heads/develop"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_deployer" {
+  name               = "github-actions-alchepnet-website-deployer"
+  description        = "Deploys the alchepnet-website develop branch from GitHub Actions"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_actions_deploy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::test.alchepnet.org"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::test.alchepnet.org/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = ["arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/EAIFBVSW6O5UF"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_deploy" {
+  name   = "deploy-website"
+  role   = aws_iam_role.github_actions_deployer.id
+  policy = data.aws_iam_policy_document.github_actions_deploy.json
+}
+
+import {
+  to = aws_iam_role.github_actions_deployer
+  id = "github-actions-alchepnet-website-deployer"
+}
+
+import {
+  to = aws_iam_role_policy.github_actions_deploy
+  id = "github-actions-alchepnet-website-deployer:deploy-website"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.5.0, < 2.0.0"
 
   backend "s3" {
     key     = "alchepnet-website/terraform.tfstate"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.5.0"
 
   backend "s3" {
     key     = "alchepnet-website/terraform.tfstate"


### PR DESCRIPTION
## Summary

- manage the existing `github-actions-alchepnet-website-deployer` role and `deploy-website` inline policy in this repository
- reference the account-wide GitHub OIDC provider as a data source
- import the existing IAM objects without changing their names, trust policy, or permissions

Paired with Su-informatics-lab/ardac-dict#26.

## Validation

- `terraform fmt -check -diff -recursive`
- `terraform validate`
- IAM-only saved plan: `2 to import, 0 to add, 0 to change, 0 to destroy`

## State migration

Apply the reviewed IAM-only import plan before applying the paired ARDaC removal plan. The full Alchepnet plan currently contains unrelated CloudFront and CodePipeline drift and must not be applied as part of this migration.